### PR TITLE
Add support for direct value comparisons

### DIFF
--- a/src/IsBackedEnum.php
+++ b/src/IsBackedEnum.php
@@ -5,10 +5,10 @@ namespace Webfox\LaravelBackedEnums;
 
 /**
  * @implements \Webfox\LaravelBackedEnums\BackedEnum<string,string>
+ * @mixin \BackedEnum<string,string>
  */
 trait IsBackedEnum
 {
-
 
     protected static function ensureImplementsInterface(): void
     {
@@ -100,7 +100,7 @@ trait IsBackedEnum
     public function isA($value): bool
     {
         static::ensureImplementsInterface();
-        return $this == $value;
+        return $this->isAny([$value]);
     }
 
     public function isAn(string $value): bool
@@ -118,6 +118,12 @@ trait IsBackedEnum
     public function isAny(array $values): bool
     {
         static::ensureImplementsInterface();
+
+        if (empty($values)) {
+            return false;
+        }
+
+        $values = array_map(fn($value) => $value instanceof static ? $value : static::from($value), $values);
         return in_array($this, $values);
     }
 


### PR DESCRIPTION
Right now if you want to use `->isA` or `->isAny` or the other comparison methods you must pass in an enum instance, I.e.
```php
$user->role->isA(MyEnum::from('admin'));           // true
$user->role->isA('admin');                         // false

$user->role->isA(MyEnum::from('not-a-value'));     // exception
$user->role->isA('not-a-value');                   // false

$user->role->isAny([MyEnum::from('admin')]);       // true
$user->role->isAny(['admin']);                     // false

$user->role->isAny([MyEnum::from('not-a-value')]); // exception
$user->role->isAny(['not-a-value']);               // false
```

This PR makes it so each pair of methods will act the same whether given a string value or an enum instance.
```php
$user->role->isA(MyEnum::from('admin'));           // true
$user->role->isA('admin');                         // true

$user->role->isA(MyEnum::from('not-a-value'));     // exception
$user->role->isA('not-a-value');                   // exception

$user->role->isAny([MyEnum::from('admin')]);       // true
$user->role->isAny(['admin']);                     // true

$user->role->isAny([MyEnum::from('not-a-value')]); // exception
$user->role->isAny(['not-a-value']);               // exception
```

This also applies for isAn, isNotA, isNotAn, isNotAny